### PR TITLE
Raise (instead of crashing) when NaNs are encountered

### DIFF
--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -98,6 +98,12 @@ class Tests(TestCase):
         with self.assertRaises(ValueError):
             beam_search(self.probs, alphabet, self.beam_size, self.beam_cut_threshold)
 
+    def test_nans(self):
+        """beam_search is passed NaN values"""
+        self.probs.fill(np.NaN)
+        with self.assertRaisesRegexp(RuntimeError, "Failed to compare values"):
+            beam_search(self.probs, self.alphabet)
+
     def test_beam_search_short_alphabet(self):
         """ simple beam search test with short alphabet"""
         self.alphabet = "NAG"


### PR DESCRIPTION
Instead of raising, NaNs could also be silently dealt with, or a total ordering defined that would... pass NaNs to the end, I guess? But failing fast seems like the better option.