### PR TITLE
Modified beam_search() to work with multi-character tokens

### DIFF
--- a/src/duplex.rs
+++ b/src/duplex.rs
@@ -635,15 +635,18 @@ pub fn beam_search<D: Data<Elem = f32>, E: Data<Elem = usize>>(
         }
     }
 
-    let mut sequence = String::new();
+    let mut tokens: Vec<&str> = Vec::new();
 
     if beam[0].node != ROOT_NODE {
         for label in suffix_tree.iter_from_no_data(beam[0].node) {
-            sequence.push_str(&alphabet[label + 1]);
+            tokens.push(&alphabet[label + 1]);
         }
     }
 
-    Ok(sequence.chars().rev().collect())
+    tokens.reverse();
+    let sequence = tokens.concat();
+
+    Ok(sequence)
 }
 
 pub fn crf_beam_search<D: Data<Elem = f32>, E: Data<Elem = usize>>(

--- a/src/search.rs
+++ b/src/search.rs
@@ -283,17 +283,21 @@ pub fn beam_search<D: Data<Elem = f32>>(
     }
 
     let mut path = Vec::new();
-    let mut sequence = String::new();
+    let mut tokens: Vec<&str> = Vec::new();
 
     if beam[0].node != ROOT_NODE {
         for (label, &time) in suffix_tree.iter_from(beam[0].node) {
             path.push(time);
-            sequence.push_str(&alphabet[label + 1]);
+            tokens.push(&alphabet[label + 1]);
         }
     }
 
     path.reverse();
-    Ok((sequence.chars().rev().collect::<String>(), path))
+    tokens.reverse();
+
+    let sequence = tokens.concat();
+
+    Ok((sequence, path))
 }
 
 fn find_max(


### PR DESCRIPTION
Beam search was reversing multi-character tokens when reconstructing the decoded sequence from the beam search path. This happened because the decoded string was built by reversing the output of the suffix tree traversal, which assumes each label corresponds to a single character. When using vocabularies with multi-character tokens (e.g. "TH", "XY"), this leads to incorrect outputs like "HT" instead of "TH". This is a minimal patch to ensure that multi-letter labels remain in their original order.

Changes:
- In `search.rs` and` duplex.rs,` removed the` .chars().rev()` step when building the final decoded sequence from the beam search path. The sequence is now reconstructed directly from the ordered list of labels.

